### PR TITLE
Add feature flag RunIntegration to guard Azure functions

### DIFF
--- a/src/EprPrnIntegration.Api/UpdatePrnsFunction.cs
+++ b/src/EprPrnIntegration.Api/UpdatePrnsFunction.cs
@@ -16,6 +16,18 @@ public class UpdatePrnsFunction(IPrnService prnService, INpwdClient npwdClient,
     public async Task Run(
         [TimerTrigger("%UpdatePrnsTrigger%")] TimerInfo myTimer)
     {
+
+        if (!bool.TryParse(configuration[ConfigSettingKeys.RunIntegrationFeatureFlag], out bool isOn))
+        {
+            isOn = false;
+        }
+
+        if (!isOn)
+        {
+            logger.LogInformation("UpdatePrnsList function is turned off");
+            return;
+        }
+
         logger.LogInformation($"UpdatePrnsList function executed at: {DateTime.UtcNow}");
 
         // Read the start hour (e.g., 18 for 6 PM) from configuration

--- a/src/EprPrnIntegration.Api/UpdateProducersFunction.cs
+++ b/src/EprPrnIntegration.Api/UpdateProducersFunction.cs
@@ -16,6 +16,18 @@ public class UpdateProducersFunction(IOrganisationService organisationService, I
     [Function("UpdateProducersList")]
     public async Task Run([HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpRequest req)
     {
+
+        if (!bool.TryParse(configuration[ConfigSettingKeys.RunIntegrationFeatureFlag], out bool isOn))
+        {
+            isOn = false;
+        }
+
+        if (!isOn)
+        {
+            logger.LogInformation("UpdateProducersList function is turned off");
+            return;
+        }
+
         logger.LogInformation($"UpdateProducersList function executed at: {DateTime.UtcNow}");
 
         int startHour = GetStartHour(configuration["UpdateProducersStartHour"]);

--- a/src/EprPrnIntegration.Api/settings.json
+++ b/src/EprPrnIntegration.Api/settings.json
@@ -14,6 +14,7 @@
     "FetchNpwdIssuedPrns:Schedule": "0 0 18 * * 1-5",
     "ServiceBus:FullyQualifiedNamespace": "UseDevelopmentStorage=true",
     "ServiceBus:FetchPrnQueueName": "UseDevelopmentStorage=true",
-    "ServiceBus:ErrorPrnQueue": "UseDevelopmentStorage=true"
+    "ServiceBus:ErrorPrnQueue": "UseDevelopmentStorage=true",
+    "RunIntegration": true // feature flag
   }
 }

--- a/src/EprPrnIntegration.Common/Constants/Constants.cs
+++ b/src/EprPrnIntegration.Common/Constants/Constants.cs
@@ -13,6 +13,7 @@
     public static class ConfigSettingKeys
     {
         public const string KeyVaultUrl = "AzureKeyVaultUrl";
+        public const string RunIntegrationFeatureFlag = "RunIntegration";
 
         public static class NpwdOAuth
         {


### PR DESCRIPTION
Add feature flag **RunIntegration** which prevent PRN Integration Azure functions running unless et true.

Azure functions are:

[Function("FetchNpwdIssuedPrnsFunction")]
[Function("UpdatePrnsList")]
[Function("UpdateProducersList")]

Refer to https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_workitems/edit/481027