### PR TITLE
Remove unneccessary leading slash on save Prns endpoint

### DIFF
--- a/src/EprPrnIntegration.Common/RESTServices/PrnBackendService/PrnService.cs
+++ b/src/EprPrnIntegration.Common/RESTServices/PrnBackendService/PrnService.cs
@@ -60,7 +60,7 @@ public class PrnService : BaseHttpService, IPrnService
     public async Task SavePrn(SavePrnDetailsRequest request)
     {
         _logger.LogInformation("Saving PRN with id {EvidenceNo}", request.EvidenceNo);
-        await Post($"/prn-details", request, CancellationToken.None);
+        await Post($"prn-details", request, CancellationToken.None);
     }
 
     public async Task<List<ReconcileUpdatedPrnsResponseModel>> GetReconciledUpdatedPrns()


### PR DESCRIPTION
The endpoint for saving Prns has an extra slash at the start. This does not seems to be an issue in the cloud but caused problems running locally. To be confident of it working, the slash was removed.

Refer to work item https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_workitems/edit/502807