### PR TITLE
When polling NPWD for Prns introduce lag

### DIFF
--- a/src/EprPrnIntegration.Api.UnitTests/FetchNpwdIssuedPrnsFunctionTests.cs
+++ b/src/EprPrnIntegration.Api.UnitTests/FetchNpwdIssuedPrnsFunctionTests.cs
@@ -570,5 +570,57 @@ namespace EprPrnIntegration.Api.UnitTests
                     )), Times.Once);
         }
 
+        [Fact]
+        public async Task Run_WhenToDateChanges_Logs()
+        {
+            // Arrange
+            var npwdIssuedPrns = _fixture.CreateMany<NpwdPrn>().ToList();
+            _mockNpwdClient.Setup(client => client.GetIssuedPrns(It.IsAny<string>()))
+                           .ReturnsAsync(npwdIssuedPrns);
+
+            _mockServiceBusProvider.Setup(provider => provider.SendFetchedNpwdPrnsToQueue(It.IsAny<List<NpwdPrn>>()))
+                .Returns(Task.CompletedTask);
+
+            var deltaSyncExecution = new DeltaSyncExecution { LastSyncDateTime = DateTime.Parse("2022-01-01T00:00:00Z"), SyncType = NpwdDeltaSyncType.UpdatePrns };
+            _mockPrnUtilities.Setup(utils => utils.GetDeltaSyncExecution(It.IsAny<NpwdDeltaSyncType>())).ReturnsAsync(deltaSyncExecution);
+            _mockPrnUtilities.Setup(utils => utils.SetDeltaSyncExecution(It.IsAny<DeltaSyncExecution>(), It.IsAny<DateTime>())).Returns(Task.CompletedTask);
+
+            int lag = 20;
+            _mockConfiguration.Setup(config => config["FetchNpwdPrnsPollingLagSeconds"]).Returns(lag.ToString());
+            _mockPrnUtilities.Setup(x => x.OffsetDateTimeWithLag(It.IsAny<DateTime>(), lag.ToString())).Returns((DateTime x, string y) => x.AddSeconds(0 - lag));
+
+            // Act
+            await _function.Run(new TimerInfo());
+
+            // Assert
+            _mockPrnUtilities.Verify(provider => provider.OffsetDateTimeWithLag(It.IsAny<DateTime>(), lag.ToString()), Times.Once);
+            _mockLogger.VerifyLog(x => x.LogInformation(It.Is<string>(s => s.StartsWith("Upper date range"))));
+        }
+
+        [Fact]
+        public async Task Run_WhenToDateStaysTheSame_DoesNotLog()
+        {
+            // Arrange
+            var npwdIssuedPrns = _fixture.CreateMany<NpwdPrn>().ToList();
+            _mockNpwdClient.Setup(client => client.GetIssuedPrns(It.IsAny<string>()))
+                           .ReturnsAsync(npwdIssuedPrns);
+
+            _mockServiceBusProvider.Setup(provider => provider.SendFetchedNpwdPrnsToQueue(It.IsAny<List<NpwdPrn>>()))
+                .Returns(Task.CompletedTask);
+
+            var deltaSyncExecution = new DeltaSyncExecution { LastSyncDateTime = DateTime.Parse("2022-01-01T00:00:00Z"), SyncType = NpwdDeltaSyncType.UpdatePrns };
+            _mockPrnUtilities.Setup(utils => utils.GetDeltaSyncExecution(It.IsAny<NpwdDeltaSyncType>())).ReturnsAsync(deltaSyncExecution);
+            _mockPrnUtilities.Setup(utils => utils.SetDeltaSyncExecution(It.IsAny<DeltaSyncExecution>(), It.IsAny<DateTime>())).Returns(Task.CompletedTask);
+
+            _mockConfiguration.Setup(config => config["FetchNpwdPrnsPollingLagSeconds"]).Returns(0.ToString());
+            _mockPrnUtilities.Setup(x => x.OffsetDateTimeWithLag(It.IsAny<DateTime>(), 0.ToString())).Returns((DateTime x, string y) => x);
+            
+            // Act
+            await _function.Run(new TimerInfo());
+
+            // Assert
+            _mockLogger.VerifyLog(x => x.LogInformation(It.Is<string>(s => s.StartsWith("Upper date range"))), Times.Never);
+        }
+
     }
 }

--- a/src/EprPrnIntegration.Api/Functions/FetchNpwdIssuedPrnsFunction.cs
+++ b/src/EprPrnIntegration.Api/Functions/FetchNpwdIssuedPrnsFunction.cs
@@ -56,7 +56,13 @@ namespace EprPrnIntegration.Api.Functions
             _logger.LogInformation($"FetchNpwdIssuedPrnsFunction function started at: {DateTime.UtcNow}");
 
             var deltaRun = await _utilities.GetDeltaSyncExecution(NpwdDeltaSyncType.FetchNpwdIssuedPrns);
-            var toDate = _utilities.OffsetDateTimeWithLag(DateTime.UtcNow, _configuration["FetchNpwdPrnsPollingLagSeconds"]) ;
+
+            var now = DateTime.UtcNow;
+            var toDate = _utilities.OffsetDateTimeWithLag(now, _configuration["FetchNpwdPrnsPollingLagSeconds"]);
+            if (!toDate.Equals(now))
+            {
+                _logger.LogInformation("Upper date range {Now} rolled back to {ToDate}", now, toDate);
+            }
 
             _logger.LogInformation("Fetching From: {fromDate} and To {ToDate} dates for this execution", deltaRun.LastSyncDateTime, toDate);
 

--- a/src/EprPrnIntegration.Api/Functions/FetchNpwdIssuedPrnsFunction.cs
+++ b/src/EprPrnIntegration.Api/Functions/FetchNpwdIssuedPrnsFunction.cs
@@ -56,7 +56,7 @@ namespace EprPrnIntegration.Api.Functions
             _logger.LogInformation($"FetchNpwdIssuedPrnsFunction function started at: {DateTime.UtcNow}");
 
             var deltaRun = await _utilities.GetDeltaSyncExecution(NpwdDeltaSyncType.FetchNpwdIssuedPrns);
-            var toDate = DateTime.UtcNow;
+            var toDate = _utilities.OffsetDateTimeWithLag(DateTime.UtcNow, _configuration["FetchNpwdPrnsPollingLagSeconds"]) ;
 
             _logger.LogInformation("Fetching From: {fromDate} and To {ToDate} dates for this execution", deltaRun.LastSyncDateTime, toDate);
 

--- a/src/EprPrnIntegration.Api/settings.json
+++ b/src/EprPrnIntegration.Api/settings.json
@@ -37,6 +37,7 @@
     "NpwdIntegration:ClientSecret": "",
     "NpwdIntegration:Scope": "",
     "NpwdIntegration:AccessTokenUrl": "",
-    "NpwdIntegration:Authority": ""
+    "NpwdIntegration:Authority": "",
+    "FetchNpwdPrnsPollingLagSeconds": "15"
   }
 }

--- a/src/EprPrnIntegration.Api/settings.json
+++ b/src/EprPrnIntegration.Api/settings.json
@@ -38,6 +38,6 @@
     "NpwdIntegration:Scope": "",
     "NpwdIntegration:AccessTokenUrl": "",
     "NpwdIntegration:Authority": "",
-    "FetchNpwdPrnsPollingLagSeconds": "15"
+    "FetchNpwdPrnsPollingLagSeconds": "60"
   }
 }

--- a/src/EprPrnIntegration.Common.UnitTests/Helpers/UtilitiesTests.cs
+++ b/src/EprPrnIntegration.Common.UnitTests/Helpers/UtilitiesTests.cs
@@ -2,6 +2,7 @@
 using EprPrnIntegration.Common.Models;
 using EprPrnIntegration.Common.Models.Queues;
 using EprPrnIntegration.Common.Service;
+using FluentAssertions;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -185,4 +186,39 @@ public class UtilitiesTests
 
         Assert.Empty(csvContent); // The CSV should be empty for a null list
     }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("11223344556677889900")]
+    [InlineData("Not an integer")]
+    [InlineData("-1")]
+    public void OffsetDateTimeWithLag_WhenMisconfigured_ShouldReturnDefault(string configSeconds)
+    {
+        // Arrange
+        DateTime expectedDateTime = DateTime.UtcNow;
+        DateTime pollingDateTime = expectedDateTime.AddSeconds(15);
+
+        // Act
+        DateTime actualDateTime = _utilities.OffsetDateTimeWithLag(pollingDateTime, configSeconds);
+
+        // Assert
+        expectedDateTime.Should().Be(actualDateTime);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(10)]
+    public void OffsetDateTimeWithLag_WhenConfigured_ShouldReturnAdjsutedDateTime(int seconds)
+    {
+        // Arrange
+        DateTime expectedDateTime = DateTime.UtcNow;
+        DateTime pollingDateTime = expectedDateTime.AddSeconds(seconds);
+
+        // Act
+        DateTime actualDateTime = _utilities.OffsetDateTimeWithLag(pollingDateTime, seconds.ToString());
+
+        // Assert
+        expectedDateTime.Should().Be(actualDateTime);
+    }
+
 }

--- a/src/EprPrnIntegration.Common.UnitTests/Helpers/UtilitiesTests.cs
+++ b/src/EprPrnIntegration.Common.UnitTests/Helpers/UtilitiesTests.cs
@@ -196,7 +196,7 @@ public class UtilitiesTests
     {
         // Arrange
         DateTime expectedDateTime = DateTime.UtcNow;
-        DateTime pollingDateTime = expectedDateTime.AddSeconds(15);
+        DateTime pollingDateTime = expectedDateTime.AddSeconds(60);
 
         // Act
         DateTime actualDateTime = _utilities.OffsetDateTimeWithLag(pollingDateTime, configSeconds);

--- a/src/EprPrnIntegration.Common/Helpers/IUtilities.cs
+++ b/src/EprPrnIntegration.Common/Helpers/IUtilities.cs
@@ -9,4 +9,13 @@ public interface IUtilities
     Task SetDeltaSyncExecution(DeltaSyncExecution syncExecution, DateTime latestRun);
     void AddCustomEvent(string eventName, IDictionary<string, string> eventData);
     Task<Stream> CreateErrorEventsCsvStreamAsync(List<ErrorEvent> errorEvents);
+
+    /// <summary>
+    /// So happens the NPWD server date time is out of sync with the Epr server date time
+    /// Rollback the current date time to avoid skipping over Prns on NPWD
+    /// </summary>
+    /// <param name="theDate">The date and time to poll up to.</param>
+    /// <param name="configSeconds">The lag to offset the polling date.</param>
+    /// <returns>Current date and time set back a configurable number of seconds.</returns>
+    DateTime OffsetDateTimeWithLag(DateTime theDate, string? configSeconds);
 }

--- a/src/EprPrnIntegration.Common/Helpers/Utilities.cs
+++ b/src/EprPrnIntegration.Common/Helpers/Utilities.cs
@@ -72,4 +72,22 @@ public class Utilities(IServiceBusProvider serviceBusProvider, IConfiguration co
         stream.Position = 0;
         return stream;
     }
+
+    /// <inheritdoc/>
+    public DateTime OffsetDateTimeWithLag(DateTime theDate, string? configSeconds)
+    {
+        const int fifteenSeconds = 15;
+        int lagSeconds;
+
+        if (int.TryParse(configSeconds, out lagSeconds))
+        {
+            lagSeconds = lagSeconds >= 0 ? lagSeconds : fifteenSeconds;
+        }
+        else
+        {
+            lagSeconds = fifteenSeconds;
+        }
+
+        return theDate.Subtract(TimeSpan.FromSeconds(lagSeconds));
+    }
 }

--- a/src/EprPrnIntegration.Common/Helpers/Utilities.cs
+++ b/src/EprPrnIntegration.Common/Helpers/Utilities.cs
@@ -76,16 +76,16 @@ public class Utilities(IServiceBusProvider serviceBusProvider, IConfiguration co
     /// <inheritdoc/>
     public DateTime OffsetDateTimeWithLag(DateTime theDate, string? configSeconds)
     {
-        const int fifteenSeconds = 15;
+        const int sixtySeconds = 60;
         int lagSeconds;
 
         if (int.TryParse(configSeconds, out lagSeconds))
         {
-            lagSeconds = lagSeconds >= 0 ? lagSeconds : fifteenSeconds;
+            lagSeconds = lagSeconds >= 0 ? lagSeconds : sixtySeconds;
         }
         else
         {
-            lagSeconds = fifteenSeconds;
+            lagSeconds = sixtySeconds;
         }
 
         return theDate.Subtract(TimeSpan.FromSeconds(lagSeconds));


### PR DESCRIPTION
The timing difference on NPWD and Epr server means Prns were being overlooked and not fetched from NPWD. Introduce a lag, default 15 seconds, to compensate when polling NPWD.

Refer to bug https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_workitems/edit/509735

New configuration setting "**FetchNpwdPrnsPollingLagSeconds**": "15"