### PR TITLE
Merge changes for Prn and NPWD timing mismatch bug fix

### DIFF
--- a/src/EprPrnIntegration.Api/Functions/FetchNpwdIssuedPrnsFunction.cs
+++ b/src/EprPrnIntegration.Api/Functions/FetchNpwdIssuedPrnsFunction.cs
@@ -57,7 +57,13 @@ namespace EprPrnIntegration.Api.Functions
             _logger.LogInformation($"FetchNpwdIssuedPrnsFunction function started at: {DateTime.UtcNow}");
 
             var deltaRun = await _utilities.GetDeltaSyncExecution(NpwdDeltaSyncType.FetchNpwdIssuedPrns);
-            var toDate = DateTime.UtcNow;
+
+            var now = DateTime.UtcNow;
+            var toDate = _utilities.OffsetDateTimeWithLag(now, _configuration["FetchNpwdPrnsPollingLagSeconds"]);
+            if (!toDate.Equals(now))
+            {
+                _logger.LogInformation("Upper date range {Now} rolled back to {ToDate}", now, toDate);
+            }
 
             _logger.LogInformation("Fetching From: {fromDate} and To {ToDate} dates for this execution", deltaRun.LastSyncDateTime, toDate);
 

--- a/src/EprPrnIntegration.Api/settings.json
+++ b/src/EprPrnIntegration.Api/settings.json
@@ -49,6 +49,7 @@
     "MessagingConfig:NpwdReconcileUpdatedPrnsTemplateId": "a1b81df4-560e-4034-a3cc-282d00ee2959",
     "Service__AccountClientId": "",
     "Service__PrnClientId": "",
-    "Service__CommonDataClientId": ""
+    "Service__CommonDataClientId": "",
+    "FetchNpwdPrnsPollingLagSeconds": "60"
   }
 }

--- a/src/EprPrnIntegration.Common.UnitTests/Helpers/UtilitiesTests.cs
+++ b/src/EprPrnIntegration.Common.UnitTests/Helpers/UtilitiesTests.cs
@@ -2,6 +2,7 @@
 using EprPrnIntegration.Common.Models;
 using EprPrnIntegration.Common.Models.Queues;
 using EprPrnIntegration.Common.Service;
+using FluentAssertions;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -201,6 +202,40 @@ public class UtilitiesTests
 
         // Assert
         Assert.Equal(normalizedExpected, normalizedResult);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("11223344556677889900")]
+    [InlineData("Not an integer")]
+    [InlineData("-1")]
+    public void OffsetDateTimeWithLag_WhenMisconfigured_ShouldReturnDefault(string configSeconds)
+    {
+        // Arrange
+        DateTime expectedDateTime = DateTime.UtcNow;
+        DateTime pollingDateTime = expectedDateTime.AddSeconds(60);
+
+        // Act
+        DateTime actualDateTime = _utilities.OffsetDateTimeWithLag(pollingDateTime, configSeconds);
+
+        // Assert
+        expectedDateTime.Should().Be(actualDateTime);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(10)]
+    public void OffsetDateTimeWithLag_WhenConfigured_ShouldReturnAdjsutedDateTime(int seconds)
+    {
+        // Arrange
+        DateTime expectedDateTime = DateTime.UtcNow;
+        DateTime pollingDateTime = expectedDateTime.AddSeconds(seconds);
+
+        // Act
+        DateTime actualDateTime = _utilities.OffsetDateTimeWithLag(pollingDateTime, seconds.ToString());
+
+        // Assert
+        expectedDateTime.Should().Be(actualDateTime);
     }
 
 }

--- a/src/EprPrnIntegration.Common/Helpers/IUtilities.cs
+++ b/src/EprPrnIntegration.Common/Helpers/IUtilities.cs
@@ -9,4 +9,13 @@ public interface IUtilities
     Task SetDeltaSyncExecution(DeltaSyncExecution syncExecution, DateTime latestRun);
     void AddCustomEvent(string eventName, IDictionary<string, string> eventData);
     string CreateCsvContent(Dictionary<string, List<string>> data);
+
+    /// <summary>
+    /// So happens the NPWD server date time is out of sync with the Epr server date time
+    /// Rollback the current date time to avoid skipping over Prns on NPWD
+    /// </summary>
+    /// <param name="theDate">The date and time to poll up to.</param>
+    /// <param name="configSeconds">The lag to offset the polling date.</param>
+    /// <returns>Current date and time set back a configurable number of seconds.</returns>
+    DateTime OffsetDateTimeWithLag(DateTime theDate, string? configSeconds);
 }

--- a/src/EprPrnIntegration.Common/Helpers/Utilities.cs
+++ b/src/EprPrnIntegration.Common/Helpers/Utilities.cs
@@ -66,4 +66,22 @@ public class Utilities(IServiceBusProvider serviceBusProvider, IConfiguration co
 
         return contentBuilder.ToString();
     }
+
+    /// <inheritdoc/>
+    public DateTime OffsetDateTimeWithLag(DateTime theDate, string? configSeconds)
+    {
+        const int sixtySeconds = 60;
+        int lagSeconds;
+
+        if (int.TryParse(configSeconds, out lagSeconds))
+        {
+            lagSeconds = lagSeconds >= 0 ? lagSeconds : sixtySeconds;
+        }
+        else
+        {
+            lagSeconds = sixtySeconds;
+        }
+
+        return theDate.Subtract(TimeSpan.FromSeconds(lagSeconds));
+    }
 }


### PR DESCRIPTION
Cherry pick big fix changes already merged to R8 to subtract 60 seconds (configurable) from the upper date and time range when polling NPWD because there server time is out of step with Epr.

Refer to bug story https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_workitems/edit/509735