### PR TITLE
Add custom event logging after succesfully updating Prns on NPWD

### DIFF
--- a/src/EprPrnIntegration.Api/Functions/UpdatePrnsFunction.cs
+++ b/src/EprPrnIntegration.Api/Functions/UpdatePrnsFunction.cs
@@ -74,6 +74,8 @@ public class UpdatePrnsFunction(IPrnService prnService, INpwdClient npwdClient,
                     $"Prns list successfully updated in NPWD for time period {fromDate} to {toDate}.");
 
                 await utilities.SetDeltaSyncExecution(deltaRun, toDate);
+
+                LogCustomEvents(npwdUpdatedPrns.Value);
                 // Insert sync data into common prn backend
                 await prnService.InsertPeprNpwdSyncPrns(npwdUpdatedPrns.Value);
             }
@@ -94,6 +96,21 @@ public class UpdatePrnsFunction(IPrnService prnService, INpwdClient npwdClient,
         catch (Exception ex)
         {
             logger.LogError(ex, $"Failed to patch NpwdUpdatedPrns for {npwdUpdatedPrns?.ToString()}");
+        }
+    }
+
+    private void LogCustomEvents(IEnumerable<UpdatedPrnsResponseModel> npwdUpdatedPrns)
+    {
+        foreach (var prn in npwdUpdatedPrns)
+        {
+            Dictionary<string, string> eventData = new()
+                {
+                    { "EvidenceNo", prn.EvidenceNo },
+                    { "EvidenceStatusCode", prn.EvidenceStatusCode },
+                    { "StatusDate", prn.StatusDate.GetValueOrDefault().ToUniversalTime().ToString() }
+                };
+
+            utilities.AddCustomEvent(CustomEvents.UpdatePrn, eventData);
         }
     }
 }

--- a/src/EprPrnIntegration.Api/Functions/UpdatePrnsFunction.cs
+++ b/src/EprPrnIntegration.Api/Functions/UpdatePrnsFunction.cs
@@ -75,9 +75,10 @@ public class UpdatePrnsFunction(IPrnService prnService, INpwdClient npwdClient,
 
                 await utilities.SetDeltaSyncExecution(deltaRun, toDate);
 
-                LogCustomEvents(npwdUpdatedPrns.Value);
                 // Insert sync data into common prn backend
                 await prnService.InsertPeprNpwdSyncPrns(npwdUpdatedPrns.Value);
+
+                LogCustomEvents(npwdUpdatedPrns.Value);
             }
             else
             {

--- a/src/EprPrnIntegration.Common/Constants/Constants.cs
+++ b/src/EprPrnIntegration.Common/Constants/Constants.cs
@@ -58,6 +58,7 @@
         public const string IssuedPrn = "IssuedPrn";
         public const string UpdateProducer = "UpdateProducer";
         public const string NpwdPrnValidationError = "NpwdPrnValidationError";
+        public const string UpdatePrn = "UpdatePrnOnNpwd";
     }
 
     public static class CustomEventFields


### PR DESCRIPTION
After updating Prns statuses on NPWD so they match Epr, create a custom event row in Application Insights for each updated Prn.

Refer to work item https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_workitems/edit/515016 in Azure DevOps