### PR TITLE
Merge custom event logging for updaitng Npwd Prns to main

### DIFF
--- a/src/EprPrnIntegration.Api/Functions/UpdatePrnsFunction.cs
+++ b/src/EprPrnIntegration.Api/Functions/UpdatePrnsFunction.cs
@@ -74,8 +74,11 @@ public class UpdatePrnsFunction(IPrnService prnService, INpwdClient npwdClient,
                     $"Prns list successfully updated in NPWD for time period {fromDate} to {toDate}.");
 
                 await utilities.SetDeltaSyncExecution(deltaRun, toDate);
+ 
                 // Insert sync data into common prn backend
                 await prnService.InsertPeprNpwdSyncPrns(npwdUpdatedPrns.Value);
+
+                LogCustomEvents(npwdUpdatedPrns.Value);
             }
             else
             {
@@ -94,6 +97,21 @@ public class UpdatePrnsFunction(IPrnService prnService, INpwdClient npwdClient,
         catch (Exception ex)
         {
             logger.LogError(ex, $"Failed to patch NpwdUpdatedPrns for {npwdUpdatedPrns?.ToString()}");
+        }
+    }
+
+    private void LogCustomEvents(IEnumerable<UpdatedPrnsResponseModel> npwdUpdatedPrns)
+    {
+        foreach (var prn in npwdUpdatedPrns)
+        {
+            Dictionary<string, string> eventData = new()
+                {
+                    { "EvidenceNo", prn.EvidenceNo },
+                    { "EvidenceStatusCode", prn.EvidenceStatusCode },
+                    { "StatusDate", prn.StatusDate.GetValueOrDefault().ToUniversalTime().ToString() }
+                };
+
+            utilities.AddCustomEvent(CustomEvents.UpdatePrn, eventData);
         }
     }
 }

--- a/src/EprPrnIntegration.Common/Constants/Constants.cs
+++ b/src/EprPrnIntegration.Common/Constants/Constants.cs
@@ -58,6 +58,7 @@
         public const string IssuedPrn = "IssuedPrn";
         public const string UpdateProducer = "UpdateProducer";
         public const string NpwdPrnValidationError = "NpwdPrnValidationError";
+        public const string UpdatePrn = "UpdatePrnOnNpwd";
     }
 
     public static class CustomEventFields


### PR DESCRIPTION
Cherry pick changes made to add custom event logging when updating Prns into the main branch. The changes were originally made on the 8.1 release branch.

Refer to Azure DevOps work item https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_workitems/edit/515016