### PR TITLE
MO-27: Use RREPW obligation year for RPD PRNs

### DIFF
--- a/src/EprPrnIntegration.Api.IntegrationTests/Functions/FetchRrepwIssuedPrnsTests.cs
+++ b/src/EprPrnIntegration.Api.IntegrationTests/Functions/FetchRrepwIssuedPrnsTests.cs
@@ -28,6 +28,7 @@ public class FetchRrepwIssuedPrnsTests : IntegrationTestBase
             var jsonDocument = JsonDocument.Parse(entry.Request.Body!);
 
             jsonDocument.RootElement.GetProperty("prnNumber").GetString().Should().Be(prnNumber);
+            jsonDocument.RootElement.GetProperty("obligationYear").GetString().Should().Be("2025");
 
             entry.Response.StatusCode.Should().Be(202);
         });

--- a/src/EprPrnIntegration.Api.IntegrationTests/Stubs/RrepwApi.cs
+++ b/src/EprPrnIntegration.Api.IntegrationTests/Stubs/RrepwApi.cs
@@ -136,6 +136,7 @@ public class RrepwApi(WireMockContext wiremock)
                 },
                 IsDecemberWaste = false,
                 IsExport = false,
+                ObligationYear = 2025,
                 TonnageValue = 100,
                 IssuerNotes = "Test notes",
             })

--- a/src/EprPrnIntegration.Api.UnitTests/FetchRrepwIssuedPrnsFunctionTests.cs
+++ b/src/EprPrnIntegration.Api.UnitTests/FetchRrepwIssuedPrnsFunctionTests.cs
@@ -455,6 +455,7 @@ public class FetchRrepwIssuedPrnsFunctionTests
             },
             IsDecemberWaste = false,
             IsExport = false,
+            ObligationYear = accreditationYear,
             TonnageValue = tonnes,
             IssuerNotes = "Test PRN",
         };

--- a/src/EprPrnIntegration.Common.UnitTests/Mappers/RrepwMappersTests.cs
+++ b/src/EprPrnIntegration.Common.UnitTests/Mappers/RrepwMappersTests.cs
@@ -47,7 +47,7 @@ public class RrepwMappersTests
 
     private PackagingRecyclingNote CreatePackagingRecyclingNote()
     {
-        return _fixture.Build<PackagingRecyclingNote>().Create();
+        return _fixture.Build<PackagingRecyclingNote>().With(x => x.ObligationYear, 2026).Create();
     }
 
     [Theory]
@@ -68,10 +68,10 @@ public class RrepwMappersTests
     public void ShouldMapPackagingRecyclingNoteToPrn_WithNulls()
     {
         var prn = new PackagingRecyclingNote();
+
         var savePrnDetailsRequest = RrepwMappers.Map(prn, _ => { });
-        savePrnDetailsRequest
-            .Should()
-            .BeEquivalentTo(new SavePrnDetailsRequest { ObligationYear = "2026" });
+
+        savePrnDetailsRequest.ObligationYear.Should().BeNull();
     }
 
     [Theory]
@@ -292,7 +292,9 @@ public class RrepwMappersTests
         savePrnDetailsRequest.IsExport.Should().Be(prn.IsExport);
         savePrnDetailsRequest.TonnageValue.Should().Be(prn.TonnageValue);
         savePrnDetailsRequest.IssuerNotes.Should().Be(prn.IssuerNotes);
-        savePrnDetailsRequest.ObligationYear.Should().Be("2026");
+        savePrnDetailsRequest
+            .ObligationYear.Should()
+            .Be(prn.ObligationYear!.Value.ToString());
     }
 
     [Fact]
@@ -610,6 +612,7 @@ public class RrepwMappersTests
     {
         return new PackagingRecyclingNote
         {
+            ObligationYear = 2026,
             Accreditation = new Accreditation
             {
                 AccreditationYear = year

--- a/src/EprPrnIntegration.Common/Mappers/RrepwMappers.cs
+++ b/src/EprPrnIntegration.Common/Mappers/RrepwMappers.cs
@@ -25,7 +25,7 @@ public static class RrepwMappers
             ReprocessingSite = GetReprocessingSite(source),
             DecemberWaste = source.IsDecemberWaste,
             ProcessToBeUsed = ConvertMaterialToProcessToBeUsed(source),
-            ObligationYear = "2026",
+            ObligationYear = source.ObligationYear?.ToString(),
             MaterialName = ConvertMaterialToEprnMaterial(source),
             IssueDate = GetAuthorizedAt(source),
             StatusUpdatedOn = GetStatusUpdatedOn(source),

--- a/src/EprPrnIntegration.Common/Models/Rrepw/PackagingRecyclingNote.cs
+++ b/src/EprPrnIntegration.Common/Models/Rrepw/PackagingRecyclingNote.cs
@@ -31,6 +31,9 @@ public class PackagingRecyclingNote
     [JsonPropertyName("isExport")]
     public bool? IsExport { get; set; }
 
+    [JsonPropertyName("obligationYear")]
+    public int? ObligationYear { get; set; }
+
     [JsonPropertyName("tonnageValue")]
     public int? TonnageValue { get; set; }
 

--- a/src/EprPrnIntegration.Common/RESTServices/RrepwService/StubbedRrepwService.cs
+++ b/src/EprPrnIntegration.Common/RESTServices/RrepwService/StubbedRrepwService.cs
@@ -419,6 +419,7 @@ namespace EprPrnIntegration.Common.RESTServices.RrepwService
                 Accreditation = accreditation,
                 IsDecemberWaste = scenario.IsDecemberWaste,
                 IsExport = scenario.IsExport,
+                ObligationYear = accreditation.AccreditationYear,
                 TonnageValue = scenario.TonnageValue,
                 IssuerNotes =
                     scenario.IssuerNotes ?? $"Stubbed PRN-{scenario.ScenarioId} for AC testing",
@@ -442,6 +443,7 @@ namespace EprPrnIntegration.Common.RESTServices.RrepwService
                 Accreditation = CreateAccreditation("13", RrepwMaterialName.Plastic),
                 IsDecemberWaste = false,
                 IsExport = false,
+                ObligationYear = 2026,
                 TonnageValue = tonnageValue,
                 IssuerNotes = $"Stubbed PRN-13 for AC3 update testing - tonnage: {tonnageValue}",
             };


### PR DESCRIPTION
## What

Pass the obligation year provided by RREPW to the common PRN backend when synchronising issued PRNs.

## Why

MO-27 replaces the temporary hard-coded `2026` value before RREPW must support multi-year December waste. The Jira ticket has no populated Acceptance Criteria field; its description identifies this replacement as the intended outcome.

## Implementation

- Deserialize `obligationYear` from each RREPW PRN list item.
- Map it to the common-backend PRN request using the same nullable conversion used for `accreditationYear`; there is no fallback value.
- Preserve the existing downstream validation: a missing or invalid year is rejected by `epr-prn-common-backend` with HTTP 400, which the integration logs, skips, and checkpoints as it does for other non-transient validation failures.
- Make the local RREPW stubs carry an explicit obligation year.

## Testing approach

- Mapper coverage verifies a provided year is propagated and an absent year remains absent—never a fabricated default.
- End-to-end fetch coverage stubs RREPW with 2025 and asserts that the RPD write has `obligationYear: "2025"`.

## Verification

- `dotnet test src/EprPrnIntegration.Common.UnitTests/EprPrnIntegration.Common.UnitTests.csproj --no-restore --filter "FullyQualifiedName~RrepwMappersTests"` — passed (64 tests).
- Earlier focused end-to-end test passed for the provided-year path; the final adjustment only aligns missing-year behaviour with the established accreditation-year path.
- Repository-wide `dotnet format ... --verify-no-changes` is currently blocked by pre-existing whitespace violations in unrelated files.

## Data and rollout

- No database migrations or configuration changes.
- Deploy only after the RREPW external list endpoint provides `obligationYear`; otherwise the downstream common backend will reject the PRN with its existing 400 validation.

## Scope and follow-up

- Does not change `epr-prn-common-backend` validation or the existing non-transient 400/checkpoint behaviour for missing mandatory data.
- The handling of skipped invalid PRNs is an existing broader reliability concern, outside MO-27.
