### PR TITLE
MO-463: Send obligation year when accepting PRNs

### DIFF
--- a/src/EprPrnIntegration.Api.IntegrationTests/Functions/UpdateRrepwPrnsTests.cs
+++ b/src/EprPrnIntegration.Api.IntegrationTests/Functions/UpdateRrepwPrnsTests.cs
@@ -18,6 +18,7 @@ public class UpdateRrepwPrnsTests : IntegrationTestBase
         return _fixture
             .Build<PrnUpdateStatus>()
             .With(p => p.PrnStatusId, (int)eprnStatus)
+            .With(p => p.ObligationYear, "2027")
             .CreateMany(count)
             .ToList();
     }
@@ -25,7 +26,7 @@ public class UpdateRrepwPrnsTests : IntegrationTestBase
     [Theory]
     [InlineData(EprnStatus.ACCEPTED)]
     [InlineData(EprnStatus.REJECTED)]
-    public async Task WhenAzureFunctionIsInvoked_SendsAcceptedPrnToRrepw(EprnStatus eprnStatus)
+    public async Task WhenAzureFunctionIsInvoked_SendsPrnStatusToRrepw(EprnStatus eprnStatus)
     {
         var payload = CreatePrns(eprnStatus);
         await PrnApiStub.HasModifiedPrns(payload);
@@ -53,6 +54,15 @@ public class UpdateRrepwPrnsTests : IntegrationTestBase
                     .GetDateTime()
                     .Should()
                     .Be(prnUpdate.StatusDate);
+
+                if (eprnStatus == EprnStatus.ACCEPTED)
+                {
+                    jsonDocument.RootElement.GetProperty("obligationYear").GetInt32().Should().Be(2027);
+                }
+                else
+                {
+                    jsonDocument.RootElement.TryGetProperty("obligationYear", out _).Should().BeFalse();
+                }
 
                 request.Response.StatusCode.Should().Be(200);
             }

--- a/src/EprPrnIntegration.Common.UnitTests/RESTServices/RrepwService/RrepwServiceTests.cs
+++ b/src/EprPrnIntegration.Common.UnitTests/RESTServices/RrepwService/RrepwServiceTests.cs
@@ -61,6 +61,7 @@ public class RrepwServiceTests
             PrnStatusId = (int)EprnStatus.ACCEPTED,
             SourceSystemId = "something",
             StatusDate = DateTime.Now,
+            ObligationYear = "2027",
         };
         await _service.UpdatePrn(prn);
         _mockHandler.Request!.Method.Should().Be(HttpMethod.Post);
@@ -71,6 +72,7 @@ public class RrepwServiceTests
         using var doc = JsonDocument.Parse(content);
         var value = doc.RootElement.GetProperty("acceptedAt").GetDateTime();
         value.Should().Be(prn.StatusDate);
+        doc.RootElement.GetProperty("obligationYear").GetInt32().Should().Be(2027);
     }
 
     [Fact]
@@ -83,6 +85,7 @@ public class RrepwServiceTests
             PrnStatusId = (int)EprnStatus.REJECTED,
             SourceSystemId = "something",
             StatusDate = DateTime.Now,
+            ObligationYear = "2027",
         };
         await _service.UpdatePrn(prn);
         _mockHandler.Request!.Method.Should().Be(HttpMethod.Post);
@@ -93,6 +96,46 @@ public class RrepwServiceTests
         using var doc = JsonDocument.Parse(content);
         var value = doc.RootElement.GetProperty("rejectedAt").GetDateTime();
         value.Should().Be(prn.StatusDate);
+        doc.RootElement.TryGetProperty("obligationYear", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ShouldUpdatePrns_AcceptedWithNullObligationYear_DoesNotIncludeObligationYear()
+    {
+        var prn = new PrnUpdateStatus
+        {
+            AccreditationYear = "2024",
+            PrnNumber = "123",
+            PrnStatusId = (int)EprnStatus.ACCEPTED,
+            SourceSystemId = "something",
+            StatusDate = DateTime.Now,
+            ObligationYear = null,
+        };
+
+        await _service.UpdatePrn(prn);
+
+        var content = await _mockHandler.Request!.Content!.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(content);
+        doc.RootElement.TryGetProperty("obligationYear", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ShouldUpdatePrns_AcceptedWithInvalidObligationYear_ThrowsFormatException()
+    {
+        var prn = new PrnUpdateStatus
+        {
+            AccreditationYear = "2024",
+            PrnNumber = "123",
+            PrnStatusId = (int)EprnStatus.ACCEPTED,
+            SourceSystemId = "something",
+            StatusDate = DateTime.Now,
+            ObligationYear = "invalid",
+        };
+
+        Func<Task> act = () => _service.UpdatePrn(prn);
+
+        await act.Should().ThrowAsync<FormatException>();
+        _mockHandler.Request.Should().BeNull();
     }
 
     [Theory]

--- a/src/EprPrnIntegration.Common/Models/PrnUpdateStatus.cs
+++ b/src/EprPrnIntegration.Common/Models/PrnUpdateStatus.cs
@@ -20,4 +20,7 @@ public class PrnUpdateStatus
 
     [JsonPropertyName("sourceSystemId")]
     public required string SourceSystemId { get; set; }
+
+    [JsonPropertyName("obligationYear")]
+    public string? ObligationYear { get; set; }
 }

--- a/src/EprPrnIntegration.Common/Models/Rrepw/AcceptPackagingRecyclingNoteRequest.cs
+++ b/src/EprPrnIntegration.Common/Models/Rrepw/AcceptPackagingRecyclingNoteRequest.cs
@@ -8,4 +8,8 @@ public class AcceptPackagingRecyclingNoteRequest
 {
     [JsonPropertyName("acceptedAt")]
     public DateTime? AcceptedAt { get; set; }
+
+    [JsonPropertyName("obligationYear")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? ObligationYear { get; set; }
 }

--- a/src/EprPrnIntegration.Common/RESTServices/RrepwService/RrepwService.cs
+++ b/src/EprPrnIntegration.Common/RESTServices/RrepwService/RrepwService.cs
@@ -137,7 +137,13 @@ namespace EprPrnIntegration.Common.RESTServices.RrepwService
                 );
                 return await PostAsync(
                     RrepwRoutes.AcceptPrnRoute(prn.PrnNumber),
-                    new { acceptedAt = prn.StatusDate }
+                    new AcceptPackagingRecyclingNoteRequest
+                    {
+                        AcceptedAt = prn.StatusDate,
+                        ObligationYear = prn.ObligationYear is null
+                            ? null
+                            : int.Parse(prn.ObligationYear),
+                    }
                 );
             }
             else if (prn.PrnStatusId == (int)EprnStatus.REJECTED)


### PR DESCRIPTION
## What

When the Azure Function accepts an RPD PRN in RREPW, it now includes the RPD obligation year as a JSON number.

## Why

MO-463 completes the outbound acceptance path now that RREPW supports obligation-year selection for December-waste PRNs. The ticket requires the field for accepted PRNs when RPD has a value, a numeric JSON value, and no field on rejection.

## Implementation

- Read the nullable `obligationYear` returned by the common PRN backend's modified-PRNs endpoint.
- Convert a non-null source value to an integer and include it in the RREPW accept request.
- Omit the field when the source value is null.
- Fail fast on a non-null value that cannot be parsed as an integer, rather than silently accepting incomplete data.
- Keep rejection requests unchanged: they contain only `rejectedAt`.

## Testing approach

- Service tests cover numeric acceptance payloads, omission for a null source value, failure for an invalid non-null value, and omission from rejection payloads.
- Compose-backed function tests assert the accepted payload contains a JSON number and the rejected payload has no `obligationYear` property.

## Verification

- `dotnet test src/EprPrnIntegration.Common.UnitTests/EprPrnIntegration.Common.UnitTests.csproj --no-restore --filter "FullyQualifiedName~RrepwServiceTests" -m:1 -nodeReuse:false --disable-build-servers` — passed (39 tests).
- `dotnet test src/EprPrnIntegration.Api.IntegrationTests/EprPrnIntegration.Api.IntegrationTests.csproj --no-restore --filter "FullyQualifiedName~UpdateRrepwPrnsTests.WhenAzureFunctionIsInvoked_SendsPrnStatusToRrepw" -m:1 -nodeReuse:false --disable-build-servers` — passed (2 tests).
- Scoped `dotnet format src/EprPrnIntegration.sln --verify-no-changes --no-restore --include ...` — passed.

## Data and rollout

- No migrations or configuration changes.
- This depends on the merged RREPW acceptance contract from PAE-1843, which accepts an optional integer `obligationYear`.

## Scope and follow-up

- This is stacked on #259 (MO-27), which supplies the matching RREPW-to-RPD direction.
- No changes are required in RREPW for this ticket; PAE-1843 is already merged there.
